### PR TITLE
getKobble not returned anymore a property kobble but each properties

### DIFF
--- a/learning/quickstart/next.mdx
+++ b/learning/quickstart/next.mdx
@@ -242,7 +242,7 @@ To make your life simpler, we crafted various Next.js examples that you ca find 
         import { getKobble } from '@kobbleio/next/server'
 
         export default async function handler(req, res) {
-            const { kobble } = await getKobble();
+            const kobble = await getKobble();
 
             const isAllowed = await kobble.acl.hasPermission('permission-name');
 
@@ -284,7 +284,7 @@ To make your life simpler, we crafted various Next.js examples that you ca find 
         import { getKobble } from '@kobbleio/next/server'
 
         export default async function handler(req, res) {
-            const { kobble } = await getKobble();
+            const kobble = await getKobble();
 
             const isAllowed = await kobble.acl.hasRemainingQuota('quota-name');
 


### PR DESCRIPTION
The code could be find here: https://github.com/kobble-io/next/blob/main/src/server/kobble.ts
In the same script, the same method getKobble is used like `const kobble = getKobble()` 